### PR TITLE
[HOTFIX]: Unnecesary image on the build

### DIFF
--- a/utils/build_new_version.sh
+++ b/utils/build_new_version.sh
@@ -28,6 +28,8 @@ cd $copy
 
 # We remove git since we don't want it in the final build
 rm -rf .git
+rm readme.png
+rm *.md
 
 # Move out of the copy directory
 cd ..


### PR DESCRIPTION
Markdown files and the readme image were being included in the final build of the package adding a huge amount of size to the build (from 50kb to around 750kb) and now is even lower since I also  removed the markdown files, build is around ~ 6kb